### PR TITLE
Added leadboard backend and frontend, Pagination, Season filter.

### DIFF
--- a/src/app/assets/ranks/rank-solo.svg
+++ b/src/app/assets/ranks/rank-solo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.1 0.9 12.2 10.2">
+	<path d="M 4 2 L 4 8 L 7 11 L 8 10 L 8 4 L 5 1 Z M 12 6 L 10 4 L 10 8 Z M 0 6 L 2 4 L 2 8 Z Z" fill="#fff"/>
+</svg>

--- a/src/app/components/input/SeasonSelector.tsx
+++ b/src/app/components/input/SeasonSelector.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { Select, SelectProps, useMantineTheme } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import Extrusion, { CornerLocation } from "../cosmetic/Extrusion";
+import { cn } from "@/app/utils/cn";
+
+export function SeasonSelector(props: SelectProps) {
+  const theme = useMantineTheme();
+  const [focused, { toggle }] = useDisclosure();
+
+  return (
+    <div>
+      <Select
+        size="md"
+        placeholder="Select Season"
+        data={["Season 0", "Season 1"]}
+        onFocus={toggle}
+        onBlur={toggle}
+        allowDeselect={false}
+        styles={{
+          input: { borderBottomLeftRadius: "0px" },
+        }}
+        {...props}
+      />{" "}
+      <Extrusion
+        className={cn(
+          "min-w-12",
+          focused ? "border-primary-5" : "border-surface-4"
+        )}
+        cornerLocation={CornerLocation.BottomRight}
+      />
+    </div>
+  );
+}

--- a/src/app/components/navigation/navbar.tsx
+++ b/src/app/components/navigation/navbar.tsx
@@ -3,7 +3,7 @@ import { Burger, Container, Group } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { CornerLocation } from "../cosmetic/Extrusion";
 import { IconBrandDiscordFilled } from "@tabler/icons-react";
-import Logo from "./Logo";
+import Logo from "./logo";
 import Extrusion from "../cosmetic/Extrusion";
 
 const links = [

--- a/src/app/components/tables/PlayerLeaderboardTable.tsx
+++ b/src/app/components/tables/PlayerLeaderboardTable.tsx
@@ -1,0 +1,87 @@
+import { Table } from "@mantine/core";
+import { cn } from "@/app/utils/cn";
+import Extrusion, { CornerLocation } from "../cosmetic/Extrusion";
+
+interface PlayerRow {
+  username: string;
+  placement: number;
+  soloRank: string;
+  playerId: string;
+  rating: number;
+}
+
+interface PlayerLeaderboardTableProps {
+  playerRows: PlayerRow[];
+  page: number;
+}
+
+const PlayerLeaderboardTable: React.FC<PlayerLeaderboardTableProps> = ({
+  playerRows,
+  page,
+}) => {
+  const ENTRIES_PER_PAGE = 50;
+  const rows = playerRows.map((playerRow) => {
+    if (
+      playerRow.placement <= page * ENTRIES_PER_PAGE &&
+      playerRow.placement > (page - 1) * ENTRIES_PER_PAGE
+    ) {
+      return (
+        <Table.Tr
+          key={playerRow.playerId}
+          className="hover:bg-surface-7 hover:text-primary-5 hover:cursor-pointer bg-surface-8 border-b-surface-7"
+        >
+          <Table.Td>
+            <p className="text-lg">{playerRow.placement}</p>
+          </Table.Td>
+          <Table.Td>
+            <p className="text-lg">{playerRow.username}</p>
+          </Table.Td>
+          <Table.Td>
+            <p className="text-lg">{playerRow.soloRank}</p>
+          </Table.Td>
+          <Table.Td>
+            <p className="text-lg">{playerRow.rating}</p>
+          </Table.Td>
+        </Table.Tr>
+      );
+    }
+  });
+
+  return (
+    <>
+      <Extrusion
+        className={cn("min-w-24 border-surface-5")}
+        cornerLocation={CornerLocation.TopRight}
+      />
+      <Table
+        stickyHeader
+        stickyHeaderOffset={5}
+        verticalSpacing="sm"
+        styles={{
+          table: { color: "white" },
+        }}
+        highlightOnHover
+      >
+        <Table.Thead className="bg-surface-5">
+          <Table.Tr>
+            <Table.Th>
+              <h1 className="text-xl sm:text-2xl font-normal">#</h1>
+            </Table.Th>
+            <Table.Th>
+              <h1 className="text-xl sm:text-2xl font-normal">Username</h1>
+            </Table.Th>
+            <Table.Th>
+              <h1 className="text-xl sm:text-2xl font-normal">Rank</h1>
+            </Table.Th>
+            <Table.Th>
+              <h1 className="text-xl sm:text-2xl font-normal">Rank Rating</h1>
+            </Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>{rows}</Table.Tbody>
+      </Table>
+    </>
+  );
+};
+
+export default PlayerLeaderboardTable;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { MantineProvider, ColorSchemeScript, mantineHtmlProps } from "@mantine/core";
 import { mantineTheme, santaiFont } from "./styles/theme";
-import Navbar from "./components/navigation/Navbar";
+import Navbar from "./components/navigation/navbar";
 import "@mantine/core/styles.css";
 import "./styles/global.css";
 

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { useState, useEffect } from "react";
+// IMAGES
+import BackgroundImage from "../components/cosmetic/BackgroundImage";
+import BackgroundImageData from "../assets/background-images/background-spectators.png";
+import soloRank from "../assets/ranks/rank-solo.svg";
+import Image from "next/image";
+// MANTINE
+import { Container, SimpleGrid, Pagination, Select } from "@mantine/core";
+// LEADERBOARD
+import PlayerLeaderboardTable from "../components/tables/PlayerLeaderboardTable";
+import { fetchLeaderboard } from "../utils/fetch/fetchLeaderboard";
+import type { LeaderboardId } from "../utils/types/leaderboard";
+// STYLING
+import Extrusion, { CornerLocation } from "../components/cosmetic/Extrusion";
+import { cn } from "../utils/cn";
+import { SeasonSelector } from "../components/input/SeasonSelector";
+
+const PRIMARY_COL_HEIGHT = "300px";
+
+// UNFINISHED
+// Need to rework the pagination so that it only pulls needed entries, to reduce load time. 
+// Need to check it doesnt break on mobile view, though it looks fine on my phone.
+
+export default function Leaderboard() {
+  const SECONDARY_COL_HEIGHT = `calc(${PRIMARY_COL_HEIGHT} / 2 - var(--mantine-spacing-md) / 2)`;
+  const DEFAULT_SEASON_VALUE = "Season 0";
+
+  const [page, setPage] = useState(1);
+  const [season, setSeason] = useState<string | null>(DEFAULT_SEASON_VALUE);
+  const [leaderboard, setLeaderboard] = useState([]);
+
+  const formatSeasonKey = (season: string | null): string => {
+    return season ? season.toLowerCase().replace(" ", "") : "";
+  };
+
+  useEffect(() => {
+    const fetchLeaderboardData = async () => {
+      const formattedSeason = formatSeasonKey(season);
+      const data = await fetchLeaderboard(formattedSeason as LeaderboardId);
+      setLeaderboard(data);
+    };
+
+    fetchLeaderboardData();
+  }, [season]);
+
+  return (
+    <main>
+      <BackgroundImage image={BackgroundImageData} />
+
+      <Container my="md" size="xl" px="0.5rem">
+        {/* TITLE START */}
+        <div className="flex justify-start items-center mt-2">
+          <div className="mr-8">
+            <h2 className="text-3xl font-light">PLAYERS</h2>
+            <h1 className="text-5xl">TOP 1000</h1>
+          </div>
+          <Image
+            src={soloRank}
+            alt="Spectre Divide solo rank icon."
+            className="w-24"
+          />
+        </div>
+        {/* FILTERS START */}
+        <div className="w-full flex my-8">
+          <div className="w-48">
+            <SeasonSelector
+              defaultValue={DEFAULT_SEASON_VALUE}
+              onChange={setSeason}
+            />
+          </div>
+        </div>
+        <div className="flex justify-end items-end pb-4 sm:pb-0">
+          <Pagination
+            total={leaderboard.length / 50}
+            value={page}
+            onChange={setPage}
+            withControls={false}
+          />
+        </div>
+        {/* TABLE START */}
+        <PlayerLeaderboardTable playerRows={leaderboard} page={page} />
+      </Container>
+    </main>
+  );
+}

--- a/src/app/utils/fetch/fetchLeaderboard.ts
+++ b/src/app/utils/fetch/fetchLeaderboard.ts
@@ -1,0 +1,16 @@
+import type { LeaderboardId } from "../types/leaderboard";
+import { leaderboards } from "../types/leaderboard";
+
+export async function fetchLeaderboard(leaderboardId: LeaderboardId) {
+	const leaderboard = leaderboards[leaderboardId];
+	const data = await leaderboard.fetchData();
+
+	// If the leaderboard has a transformData function, use it and return the transformed data
+	if ("transformData" in leaderboard) {
+		// @ts-ignore TS doesn't know what this funcion is because it's not used at times
+		const transformedData = leaderboard.transformData(data);
+		return transformedData;
+	}
+
+	return data;
+}

--- a/src/app/utils/fetch/noStoreFetch.ts
+++ b/src/app/utils/fetch/noStoreFetch.ts
@@ -1,0 +1,2 @@
+export default (url: string, options?: Omit<RequestInit, "cache">) =>
+	fetch(url, { ...options, cache: "no-store" });

--- a/src/app/utils/types/leaderboard.ts
+++ b/src/app/utils/types/leaderboard.ts
@@ -1,0 +1,99 @@
+import noStoreFetch from "../fetch/noStoreFetch";
+import type { SoloPayload } from "./payload";
+import type PlayerStats from "./playerStats";
+import getSoloRankFromNumber from "./rank";
+
+export type Leaderboard = {
+  enabled: boolean;
+
+  id: string;
+  name: string;
+
+  fetchData: () => Promise<any>;
+  transformData?: (data: any[]) => any[];
+};
+
+export type LeaderboardId = keyof typeof leaderboards;
+export const defaultLeaderboardId: LeaderboardId = "season0";
+export const leaderboardIdsToPrefetch: LeaderboardId[] = ["season0"];
+
+export const leaderboards = {
+  season0: {
+    enabled: true,
+
+    id: "season0",
+    name: "Season 0",
+
+    fetchData: async () => {
+      const res = await noStoreFetch(
+        "https://wavescan-production.up.railway.app/api/v1/leaderboard/solo_ranked"
+      );
+      const data = (await res.json()) as {
+        leaderboard: {
+          id: string;
+          display_name: string;
+          current_solo_rank: number;
+          rank_rating: number;
+          rank: number;
+        }[];
+      };
+
+      const playerStats = data.leaderboard.map((d) => {
+        return {
+          username: d.display_name,
+          placement: d.rank,
+          soloRank: getSoloRankFromNumber(d.current_solo_rank),
+          playerId: d.id,
+          rating: d.rank_rating,
+        };
+      });
+      return playerStats as unknown as PlayerStats[];
+    },
+  },
+  season1: {
+    enabled: true,
+
+    id: "season0",
+    name: "Season 0",
+
+    fetchData: async () => {
+      return [
+        {
+          username: "s1player1",
+          placement: 1,
+          soloRank: "champion",
+          playerId: "ABC123",
+          rating: 7331,
+        },
+        {
+          username: "s1player2",
+          placement: 2,
+          soloRank: "champion",
+          playerId: "DEF456",
+          rating: 7025,
+        },
+        {
+          username: "s1player3",
+          placement: 3,
+          soloRank: "champion",
+          playerId: "GHI789",
+          rating: 6895,
+        },
+        {
+          username: "s1player4",
+          placement: 4,
+          soloRank: "champion",
+          playerId: "JKL012",
+          rating: 6702,
+        },
+        {
+          username: "s1player5",
+          placement: 5,
+          soloRank: "champion",
+          playerId: "MNO345",
+          rating: 6550,
+        },
+      ];
+    },
+  },
+} satisfies Record<string, Leaderboard>;

--- a/src/app/utils/types/payload.ts
+++ b/src/app/utils/types/payload.ts
@@ -1,0 +1,24 @@
+import type PlayerStats from "./playerStats";
+
+export type SoloPayload = SoloPayloadObject[];
+
+export interface CrewPayload {
+	id: number;
+	crewId: string;
+	crewName: string;
+}
+
+export interface PlayerStatsPayload {
+	id: number;
+	steamId: string;
+	playerId: string;
+	SpectreCrew: CrewPayload;
+	displayName: string;
+}
+
+export interface SoloPayloadObject {
+	rank: number;
+	currentSoloRank: number;
+	highestTeamRank: number;
+	SpectrePlayer: PlayerStatsPayload;
+}

--- a/src/app/utils/types/playerStats.ts
+++ b/src/app/utils/types/playerStats.ts
@@ -1,0 +1,7 @@
+export default interface PlayerStats {
+	username: string /* Haft */;
+	placement: number /* #1, #2... */;
+	rating: number /* SR */;
+	soloRank: string /* Unranked...Champion (as number) */;
+	playerId: string /* Spectre Divide Player ID: 9e8b8244-724d-4376-84e9-f3aad331585a */;
+}

--- a/src/app/utils/types/rank.ts
+++ b/src/app/utils/types/rank.ts
@@ -1,0 +1,36 @@
+export default function getSoloRankFromNumber(rankNumber: number): string {
+	const soloRanks: { [key: number]: string } = {
+		0: "Unranked",
+		1: "Bronze 1",
+		2: "Bronze 2",
+		3: "Bronze 3",
+		4: "Bronze 4",
+		5: "Silver 1",
+		6: "Silver 2",
+		7: "Silver 3",
+		8: "Silver 4",
+		9: "Gold 1",
+		10: "Gold 2",
+		11: "Gold 3",
+		12: "Gold 4",
+		13: "Platinum 1",
+		14: "Platinum 2",
+		15: "Platinum 3",
+		16: "Platinum 4",
+		17: "Emerald 1",
+		18: "Emerald 2",
+		19: "Emerald 3",
+		20: "Emerald 4",
+		21: "Ruby 1",
+		22: "Ruby 2",
+		23: "Ruby 3",
+		24: "Ruby 4",
+		25: "Diamond 1",
+		26: "Diamond 2",
+		27: "Diamond 3",
+		28: "Diamond 4",
+		29: "Champion",
+	};
+
+	return soloRanks[rankNumber] || "Unknown Rank";
+}


### PR DESCRIPTION
Copied over leader board backend, added a leadboard table with pagination and season filter.
Not fully finished, need to check mobile view doesn't break, and alter backend slightly so it doesn't load all 1000 entries at once.